### PR TITLE
test: spec/docs のみ変更で否定パターン検証

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,40 +1,40 @@
-name: Test YAML hash comment bug
+name: Test paths-filter negation extglob
 
 on:
-  workflow_dispatch:
-
-permissions:
-  issues: write
+  pull_request:
+    branches: [develop]
 
 jobs:
-  test:
+  paths-filter:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Generate text with hash
-        id: generate
-        uses: actions/github-script@v7
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
         with:
-          result-encoding: string
-          script: |
-            return `### feat: add new feature #123\r\nsome test content\r\n### fix: bug fix #456\r\nmore content here`;
+          list-files: json
+          filters: |
+            # パターンA: spec/**だけ
+            spec_all:
+              - 'spec/**'
 
-      # ケース1: クォートなし
-      - name: Create issue without quotes
-        env:
-          BODY: ${{ steps.generate.outputs.result }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh issue create --repo "$GITHUB_REPOSITORY" \
-            --title "Test without quotes" \
-            --body "$BODY"
+            # パターンB: 否定パターンで除外
+            spec_exclude_docs_negation:
+              - 'spec/**'
+              - '!spec/docs/**'
 
-      # ケース2: クォート付き
-      - name: Create issue with quotes
-        env:
-          BODY: "${{ steps.generate.outputs.result }}"
-          GH_TOKEN: ${{ github.token }}
+            # パターンC: extglobで除外
+            spec_exclude_docs_extglob:
+              - 'spec/!(docs)/**'
+
+      - name: Show results
         run: |
-          gh issue create --repo "$GITHUB_REPOSITORY" \
-            --title "Test with quotes" \
-            --body "$BODY"
+          echo "spec_all: ${{ steps.filter.outputs.spec_all }}"
+          echo "spec_exclude_docs_negation: ${{ steps.filter.outputs.spec_exclude_docs_negation }}"
+          echo "spec_exclude_docs_extglob: ${{ steps.filter.outputs.spec_exclude_docs_extglob }}"
+          echo "---"
+          echo "spec_all files: ${{ steps.filter.outputs.spec_all_files }}"
+          echo "spec_exclude_docs_negation files: ${{ steps.filter.outputs.spec_exclude_docs_negation_files }}"
+          echo "spec_exclude_docs_extglob files: ${{ steps.filter.outputs.spec_exclude_docs_extglob_files }}"

--- a/spec/docs/api_spec.rb
+++ b/spec/docs/api_spec.rb
@@ -1,0 +1,1 @@
+# docs only change


### PR DESCRIPTION
## Summary
- spec/docs 配下のみ変更し、否定パターンとextglobが `false` を返すか検証
- PR #17 と対になる検証（#17 は spec/docs 以外も含む → true 期待）

| フィルタ | 期待結果 |
|---|---|
| spec_all | true（spec/docs も spec/** にマッチ） |
| spec_exclude_docs_negation | false（否定パターンで除外） |
| spec_exclude_docs_extglob | false（extglobで除外） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)